### PR TITLE
Меньше ошибок, когда LCD отключен

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -586,7 +586,7 @@
   //#define MIN_BED_POWER 0
   //#define PID_BED_DEBUG // Sends debug data to the serial port.
 
-//UltiSteel 
+//UltiSteel
 #if (GITHUB_USER==URSOFT)
   #define DEFAULT_bedKp 32.27
   #define DEFAULT_bedKi 6.45
@@ -1430,7 +1430,9 @@
 #if ENABLED(LCD_BED_LEVELING)
   #define MESH_EDIT_Z_STEP  0.025 // (mm) Step size while manually probing Z axis.
   #define LCD_PROBE_Z_RANGE 4     // (mm) Z Range centered on Z_MIN_POS for LCD Z adjustment
+  #if HAS_LCD_MENU
   #define MESH_EDIT_MENU        // Add a menu to edit mesh points
+  #endif
 #endif
 
 // Add a menu item to move between bed corners for manual bed adjustment

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1430,7 +1430,9 @@
 #if ENABLED(LCD_BED_LEVELING)
   #define MESH_EDIT_Z_STEP  0.025 // (mm) Step size while manually probing Z axis.
   #define LCD_PROBE_Z_RANGE 4     // (mm) Z Range centered on Z_MIN_POS for LCD Z adjustment
+  #if HAS_LCD_MENU
   #define MESH_EDIT_MENU        // Add a menu to edit mesh points
+  #endif
 #endif
 
 // Add a menu item to move between bed corners for manual bed adjustment

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1157,7 +1157,9 @@
   #define SDCARD_RATHERRECENTFIRST
 
   //#define SD_MENU_CONFIRM_START             // Confirm the selected SD file before printing
+  #ifdef HAS_LCD_MENU
   #define SD_SHOW_FILES_ON_MEDIA_INSERTED   // https://github.com/ursoft/Marlin/issues/3
+  #endif
   //#define MENU_ADDAUTOSTART               // Add a menu option to run auto#.g files
 
   #define EVENT_GCODE_SD_ABORT "G27 P2"      // G-code to run on SD Abort Print (e.g., "G28XY" or "G27")
@@ -1239,7 +1241,7 @@
    #define LONG_FILENAME_OVERRIDE_SHORT //https://github.com/ursoft/Marlin/issues/26
    #define CYRILLIC_FILENAMES
   #endif
- 
+
   // Enable this option to scroll long filenames in the SD card menu
   //#define SCROLL_LONG_FILENAMES
 
@@ -1262,7 +1264,9 @@
   /**
    * https://github.com/ursoft/Marlin/issues/4#issuecomment-555858393
    */
+  #if HAS_LCD_MENU
   #define SD_MENU_MEDIA_SHOW_LAST_PRINT_DURATION
+  #endif
 
   /**
    * Auto-report SdCard status with M27 S<seconds>

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1241,7 +1241,7 @@
    #define LONG_FILENAME_OVERRIDE_SHORT //https://github.com/ursoft/Marlin/issues/26
    #define CYRILLIC_FILENAMES
   #endif
-
+ 
   // Enable this option to scroll long filenames in the SD card menu
   //#define SCROLL_LONG_FILENAMES
 

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1254,8 +1254,10 @@ void setup() {
 
   SETUP_LOG("setup() completed.");
   
+  #if HAS_LCD_MENU
   //clear screen to avoid flicker
   ui.clear_lcd(true);  
+  #endif
 }
 
 /**

--- a/Marlin/src/gcode/sd/M21_M22.cpp
+++ b/Marlin/src/gcode/sd/M21_M22.cpp
@@ -36,13 +36,15 @@ void GcodeSuite::M21() { card.mount(); }
 /**
  * M22: Release SD Card
  */
-void GcodeSuite::M22() { 
+void GcodeSuite::M22() {
     if(card.isPrinting()) {
       SERIAL_ERROR_MSG("No M22 while print");
     } else {
       card.release();
+#if HAS_LCD_MENU
       void menu_media();
       if(MarlinUI::currentScreen == menu_media) MarlinUI::return_to_status();
+#endif
     }
 }
 

--- a/Marlin/src/gcode/sd/M21_M22.cpp
+++ b/Marlin/src/gcode/sd/M21_M22.cpp
@@ -36,7 +36,7 @@ void GcodeSuite::M21() { card.mount(); }
 /**
  * M22: Release SD Card
  */
-void GcodeSuite::M22() {
+void GcodeSuite::M22() { 
     if(card.isPrinting()) {
       SERIAL_ERROR_MSG("No M22 while print");
     } else {

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3103,5 +3103,9 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
   #endif
 #endif
 
+#if SD_CONNECTION_IS(LCD_AND_ONBOARD) && !defined(HAS_GRAPHICAL_LCD)
+#error "LCD_AND_ONBOARD requires a graphical LCD with SD card (e.g. FYSETC_MINI_12864_2_1)"
+#endif
+
 // Misc. Cleanup
 #undef _TEST_PWM


### PR DESCRIPTION
Случайно выяснилось, что если никакой экран не указан, будет падать линковка при очистке LCD, и компиляция в ряде мест.
Может, пригодится, если потом когда-то это в апстрим добавлять.